### PR TITLE
relative imports are sorted by path

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-import-formatter",
   "displayName": "ES6 Import Formatter",
   "description": "Sort the leading imports/requires for ES6.",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "icon": "icon.png",
   "publisher": "henry-li",
   "keywords": [

--- a/src/sorters/default-sorter.js
+++ b/src/sorters/default-sorter.js
@@ -49,7 +49,9 @@ function sort(imports) {
  * @returns
  */
 function compare(a, b) {
-  return a.toLowerCase().localeCompare(b.toLowerCase());
+  const pathA = lexer.extractFilePath(a).toLowerCase();
+  const pathB = lexer.extractFilePath(b).toLowerCase();
+  return pathA.localeCompare(pathB);
 }
 
 /**


### PR DESCRIPTION
This change groups relative import on the path basis by sorting paths instead of whole import string.